### PR TITLE
Fix some include issues and incompatible pointers

### DIFF
--- a/mcp-account-manager-uoa/empathy-webcredentials-monitor.c
+++ b/mcp-account-manager-uoa/empathy-webcredentials-monitor.c
@@ -4,7 +4,7 @@
 
 #include <telepathy-glib/telepathy-glib.h>
 
-#include <libaccounts-glib/ag-account.h>
+#include <libaccounts-glib/libaccounts-glib.h>
 
 #include "empathy-webcredentials-monitor.h"
 

--- a/mcp-account-manager-uoa/empathy-webcredentials-monitor.h
+++ b/mcp-account-manager-uoa/empathy-webcredentials-monitor.h
@@ -3,7 +3,7 @@
 
 #include <glib-object.h>
 
-#include <libaccounts-glib/ag-manager.h>
+#include <libaccounts-glib/libaccounts-glib.h>
 
 G_BEGIN_DECLS
 

--- a/mcp-account-manager-uoa/mcp-account-manager-uoa.c
+++ b/mcp-account-manager-uoa/mcp-account-manager-uoa.c
@@ -23,12 +23,7 @@
 
 #include <telepathy-glib/telepathy-glib.h>
 
-#include <libaccounts-glib/ag-account.h>
-#include <libaccounts-glib/ag-account-service.h>
-#include <libaccounts-glib/ag-manager.h>
-#include <libaccounts-glib/ag-service.h>
-#include <libaccounts-glib/ag-auth-data.h>
-#include <libaccounts-glib/ag-provider.h>
+#include <libaccounts-glib/libaccounts-glib.h>
 
 #include <libsignon-glib/signon-identity.h>
 
@@ -890,7 +885,7 @@ account_manager_uoa_ready (const McpAccountStorage *storage,
   DEBUG (G_STRFUNC);
 
   self->priv->ready = TRUE;
-  self->priv->am = g_object_ref (G_OBJECT (am));
+  self->priv->am = MCP_ACCOUNT_MANAGER (g_object_ref (G_OBJECT (am)));
 
   while ((data = g_queue_pop_head (self->priv->pending_signals)) != NULL)
     {

--- a/telepathy-sasl-signon/empathy-auth-factory.c
+++ b/telepathy-sasl-signon/empathy-auth-factory.c
@@ -599,7 +599,7 @@ empathy_auth_factory_constructor (GType type,
 
   if (auth_factory_singleton != NULL)
     {
-      retval = g_object_ref (auth_factory_singleton);
+      retval = g_object_ref (G_OBJECT (auth_factory_singleton));
     }
   else
     {

--- a/telepathy-sasl-signon/empathy-keyring.c
+++ b/telepathy-sasl-signon/empathy-keyring.c
@@ -22,11 +22,7 @@
 
 #include <string.h>
 
-#include <libaccounts-glib/ag-account.h>
-#include <libaccounts-glib/ag-account-service.h>
-#include <libaccounts-glib/ag-auth-data.h>
-#include <libaccounts-glib/ag-manager.h>
-#include <libaccounts-glib/ag-service.h>
+#include <libaccounts-glib/libaccounts-glib.h>
 #include <libsignon-glib/signon-identity.h>
 #include "empathy-uoa-utils.h"
 

--- a/telepathy-sasl-signon/empathy-server-sasl-handler.c
+++ b/telepathy-sasl-signon/empathy-server-sasl-handler.c
@@ -22,8 +22,8 @@
 #include <string.h>
 
 #include "empathy-debug.h"
-//#include "empathy-keyring.h"
-//#include "empathy-sasl-mechanisms.h"
+#include "empathy-keyring.h"
+#include "empathy-sasl-mechanisms.h"
 
 enum {
   PROP_CHANNEL = 1,

--- a/telepathy-sasl-signon/empathy-uoa-auth-handler.c
+++ b/telepathy-sasl-signon/empathy-uoa-auth-handler.c
@@ -18,11 +18,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <libaccounts-glib/ag-account.h>
-#include <libaccounts-glib/ag-account-service.h>
-#include <libaccounts-glib/ag-auth-data.h>
-#include <libaccounts-glib/ag-manager.h>
-#include <libaccounts-glib/ag-service.h>
+#include <libaccounts-glib/libaccounts-glib.h>
 
 #include <libsignon-glib/signon-identity.h>
 #include <libsignon-glib/signon-auth-session.h>

--- a/telepathy-sasl-signon/empathy-uoa-utils.h
+++ b/telepathy-sasl-signon/empathy-uoa-utils.h
@@ -21,7 +21,7 @@
 #ifndef __EMPATHY_UOA_UTILS_H__
 #define __EMPATHY_UOA_UTILS_H__
 
-#include <libaccounts-glib/ag-manager.h>
+#include <libaccounts-glib/libaccounts-glib.h>
 
 #define EMPATHY_UOA_SERVICE_TYPE "IM"
 


### PR DESCRIPTION
The missing includes and incompatible pointers cause build failure with gcc 14. The libaccounts-glib include changes silence a lot of build warnings.